### PR TITLE
animationDidStop: is called for a second time after setting nextView to nil

### DIFF
--- a/CubeFlip/RSCubeView.m
+++ b/CubeFlip/RSCubeView.m
@@ -292,7 +292,10 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 - (void)animationDidStop:(CAAnimation *)animation finished:(BOOL)finished {
 	
-	isAnimating = NO;
+	if (!isAnimating)
+        return;
+    
+    isAnimating = NO;
     self.contentView = nextView;
     
     [animationLayer removeFromSuperlayer];


### PR DESCRIPTION
This patch is for a border case when animationDidStop: is being called for a second time after nextView has being already set to nil. I just added an if validation to see if the view is animated or not. This should fix this problem.

Thanks for sharing your awesome library!
